### PR TITLE
fix(search): disable search autocorrect in Safari

### DIFF
--- a/course_selection/templates/main/search.html
+++ b/course_selection/templates/main/search.html
@@ -21,6 +21,7 @@ ng-controller="SearchCtrl as searchCtrl">
                ng-init="query=''"
                select-on-click
                auto-focus
+               autocorrect="off"
                focus="true"
                placeholder="{{ searchCtrl.placeHolder}}">
         </input>


### PR DESCRIPTION
Disable autocorrect in the course search bar on Safari. Previously this would annoyingly try to correct things like "wws" to "was". This disables the autocorrect.

For documentation of this Safari-only attribute, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocorrect) and [Apple's docs](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocorrect).